### PR TITLE
Fix inline edit height problem under webkit

### DIFF
--- a/source/dbootstrap/theme/bootstrap/form/Common.styl
+++ b/source/dbootstrap/theme/bootstrap/form/Common.styl
@@ -44,6 +44,10 @@
     height: $baseLineHeight;
 }
 
+.dj_webkit .bootstrap .dijitInline .dijitInputField .dijitInputInner {
+    height: inherit;
+}
+
 .bootstrap .dijitPlaceHolder {
     font-style: normal;
     padding: 4px 6px;


### PR DESCRIPTION
Due to the recent patch of fixing the dijitInputInner to $baseLineHeight, the inline edit will be clipped if the font is large. This patch resets the height to inherit when under dijitInline.  
