### PR TITLE
Update icon_support for dojo 1.9.0

### DIFF
--- a/source/dbootstrap/icon_support.js
+++ b/source/dbootstrap/icon_support.js
@@ -57,7 +57,7 @@ function(declare, lang, array, domConstruct, domClass, TemplatedMixin) {
                 if (domClass.contains(node, reference_classes[i])) {
                     var attributes = {};
                     array.forEach(reference_attributes, function(name) {
-                        var attribute = getAttrFunc(node, name);
+                        var attribute = node.getAttribute(name);
                         if (attribute) {
                             attributes[name] = attribute;
                         }


### PR DESCRIPTION
In dojo 1.9.0, _attachTemplateNodes no longer has the getAttrFunc parameter.   Therefore, inside the _attachTemplateNodes function, it is modified to call node.getAttribute(name) directly rather than using getAttrFunc(node, name).
