### PR TITLE
IE 10 splitter dragging bug

### DIFF
--- a/source/dbootstrap/theme/dbootstrap/dijit.css
+++ b/source/dbootstrap/theme/dbootstrap/dijit.css
@@ -890,6 +890,7 @@ body .dijitAlignClient { position: absolute; }
 }
 
 .dijitSplitterCover {
+    background-color: transparent;
     position:absolute;
     z-index:-1;
     top:0;


### PR DESCRIPTION
Fix a bug in IE 10 where the screen turns white when dragging a border container pane splitter.
